### PR TITLE
Feature/inspection

### DIFF
--- a/item-api/src/main/scala/com/example/auction/item/api/ItemService.scala
+++ b/item-api/src/main/scala/com/example/auction/item/api/ItemService.scala
@@ -3,13 +3,14 @@ package com.example.auction.item.api
 import java.util.UUID
 
 import akka.{Done, NotUsed}
+import com.example.auction.item.api.monitor.InspectingEntityServiceCall
 import com.example.auction.security.SecurityHeaderFilter
 import com.example.auction.utils.PaginatedSequence
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.transport.Method
 import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
 
-trait ItemService extends Service {
+trait ItemService extends Service with InspectingEntityServiceCall {
   /**
     * Create an item.
     *
@@ -56,7 +57,11 @@ trait ItemService extends Service {
       pathCall("/api/item", createItem),
       restCall(Method.POST, "/api/item/:id/start", startAuction _),
       pathCall("/api/item/:id", getItem _),
-      pathCall("/api/item?userId&status&pageNo&pageSize", getItemsForUser _)
+      pathCall("/api/item?userId&status&pageNo&pageSize", getItemsForUser _),
+
+      restCallGetEntityNames("item"),
+      restCallInspectEntity("item")
+
     ).withTopics(
       topic("item-ItemEvent", this.itemEvents)
     ).withHeaderFilter(SecurityHeaderFilter.Composed)

--- a/item-api/src/main/scala/com/example/auction/item/api/monitor/InspectingEntityServiceCall.scala
+++ b/item-api/src/main/scala/com/example/auction/item/api/monitor/InspectingEntityServiceCall.scala
@@ -1,0 +1,21 @@
+package com.example.auction.item.api.monitor
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api.Service.restCall
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import com.lightbend.lagom.scaladsl.api.transport.Method
+
+trait InspectingEntityServiceCall {
+
+  def getEntityNames(): ServiceCall[NotUsed, Seq[String]]
+
+  def inspectEntity(entityName: String, entityId: String, from: Option[Long], to: Option[Long]): ServiceCall[NotUsed, PersistentEntityStateDto]
+
+  def restCallGetEntityNames(name: String) = {
+    restCall(Method.GET, s"/api/internal/$name/inspect/entityNames", getEntityNames _)
+  }
+
+  def restCallInspectEntity(name: String) = {
+    restCall(Method.GET, s"/api/internal/$name/inspect/entities/:entityName/:entityId?from&to", inspectEntity _)
+  }
+}

--- a/item-api/src/main/scala/com/example/auction/item/api/monitor/PersistentEntityStateDto.scala
+++ b/item-api/src/main/scala/com/example/auction/item/api/monitor/PersistentEntityStateDto.scala
@@ -1,0 +1,28 @@
+package com.example.auction.item.api.monitor
+
+import java.time.Instant
+import java.util.UUID
+
+import play.api.libs.json.{Format, JsValue, Json}
+
+case class PersistentEntityStateDto(currentState: JsValue, events: Seq[PersistentEventDto])
+
+object PersistentEntityStateDto {
+  implicit val format: Format[PersistentEntityStateDto] = Json.format
+}
+
+case class PersistentEventDto(
+                               eventName: String,
+                               persistentId: String,
+                               partitionNumber: Long,
+                               sequenceNumber: Long,
+                               timeStamp: Instant,
+                               offSet: UUID,
+                               event: JsValue,
+                               serializationManifest: String
+                             )
+
+object PersistentEventDto {
+  implicit val format: Format[PersistentEventDto] = Json.format
+}
+

--- a/item-impl/src/main/scala/com/example/auction/item/impl/monitor/EntityInspection.scala
+++ b/item-impl/src/main/scala/com/example/auction/item/impl/monitor/EntityInspection.scala
@@ -1,0 +1,81 @@
+package com.example.auction.item.impl.monitor
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.example.auction.item.api.monitor.PersistentEntityStateDto
+import com.example.auction.item.impl.monitor.ces.InspectEntityStateCmd
+import com.example.auction.item.impl.monitor.dao.EventDao
+import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
+import com.lightbend.lagom.scaladsl.persistence.{PersistentEntity, PersistentEntityRegistry}
+import play.api.libs.json.JsValue
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EntityInspectionComponent {
+
+  val entityInspectionService: EntityInspectionService
+  lazy val inspectEntityCommandRegistry = new InspectEntityCommandRegistry()
+
+}
+
+class InspectEntityCommandRegistry {
+
+  type InspectionHandler = PartialFunction[(PersistentEntityRegistry, String, InspectEntityStateCmd), Future[JsValue]]
+
+  private val entityNameKeyCommandValue = new ConcurrentHashMap[String, InspectEntityStateCmd]()
+  private val entityNameKeyInspectHandlerValue = new ConcurrentHashMap[String, InspectionHandler]()
+
+  def getEntityNames: List[String] = {
+    import scala.collection.JavaConversions._
+    entityNameKeyCommandValue.keys().toList
+  }
+
+  def getInspectCommand(entityTypeName: String): InspectEntityStateCmd = {
+    entityNameKeyCommandValue.get(entityTypeName)
+  }
+
+  def getInspectionHandler(entityTypeName: String): Option[InspectionHandler] = {
+    Option(entityNameKeyInspectHandlerValue.get(entityTypeName))
+  }
+
+  def registerInspectionHandler(entityFactory: => PersistentEntity, cmd: InspectEntityStateCmd)(handler: InspectionHandler) = {
+
+    val proto = entityFactory
+
+    val entityTypeName = proto.entityTypeName
+    entityNameKeyCommandValue.put(entityTypeName, cmd)
+    entityNameKeyInspectHandlerValue.put(entityTypeName, handler)
+  }
+}
+
+class EntityInspectionService(persistentEntityRegistry: PersistentEntityRegistry,
+                              inspectionRegistry: InspectEntityCommandRegistry,
+                              val cassandraSession: CassandraSession) extends EventDao {
+
+  def inspectEntity(entityName: String, entityId: String,
+                    from: Option[Long], to: Option[Long])(implicit ec: ExecutionContext): Future[PersistentEntityStateDto] = {
+    for {
+      currentState <- askCurrentState(entityName, entityId)
+      events <- getEvents(entityName, entityId, from, to)
+    } yield {
+      PersistentEntityStateDto(currentState, events)
+    }
+  }
+
+  def getEntityNames: Future[List[String]] = {
+    Future.successful(inspectionRegistry.getEntityNames)
+  }
+
+  private def askCurrentState(entityTypeName: String, entityId: String): Future[JsValue] = {
+    val cmd = getInspectCommand(entityTypeName)
+    inspectionRegistry.getInspectionHandler(entityTypeName) match {
+      case Some(handler) => handler(persistentEntityRegistry, entityId, cmd)
+      case None => throw new NoSuchElementException(s"No inspection has been registered for entity type [$entityTypeName]")
+    }
+  }
+
+  private def getInspectCommand(entityTypeName: String): InspectEntityStateCmd = {
+    inspectionRegistry.getInspectCommand(entityTypeName)
+  }
+
+}

--- a/item-impl/src/main/scala/com/example/auction/item/impl/monitor/ces/InspectEntityStateCmd.scala
+++ b/item-impl/src/main/scala/com/example/auction/item/impl/monitor/ces/InspectEntityStateCmd.scala
@@ -1,0 +1,7 @@
+package com.example.auction.item.impl.monitor.ces
+
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+import play.api.libs.json.JsValue
+
+trait InspectEntityStateCmd extends ReplyType[JsValue]
+

--- a/item-impl/src/main/scala/com/example/auction/item/impl/monitor/ces/InspectableEntity.scala
+++ b/item-impl/src/main/scala/com/example/auction/item/impl/monitor/ces/InspectableEntity.scala
@@ -1,0 +1,19 @@
+package com.example.auction.item.impl.monitor.ces
+
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
+import play.api.libs.json.{JsValue, Json, Writes}
+
+import scala.reflect.ClassTag
+
+trait InspectableEntity extends PersistentEntity {
+
+  protected def inspection[C <: Command with InspectEntityStateCmd : ClassTag]
+  (behavior: Behavior)(implicit tjs: Writes[State]) = {
+
+    state: State =>
+      Actions().onReadOnlyCommand[C, JsValue] {
+        case (_: C, ctx, state) => ctx.reply(Json.toJson(state))
+      }.orElse(behavior(state))
+  }
+
+}

--- a/item-impl/src/main/scala/com/example/auction/item/impl/monitor/dao/EventDao.scala
+++ b/item-impl/src/main/scala/com/example/auction/item/impl/monitor/dao/EventDao.scala
@@ -1,0 +1,104 @@
+package com.example.auction.item.impl.monitor.dao
+
+import java.time.Instant
+
+import com.datastax.driver.core.Row
+import com.example.auction.item.api.monitor.PersistentEventDto
+import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EventDao {
+
+  def cassandraSession: CassandraSession
+
+  def getEvents(entityTypeName: String, entityId: String, from: Option[Long], to: Option[Long])(implicit ex: ExecutionContext): Future[Seq[PersistentEventDto]] = {
+
+    val persistentId = makePersistentId(entityTypeName, entityId)
+
+    val jZero = java.lang.Long.valueOf(0)
+
+    val sequence: java.lang.Long = from match {
+      case None => jZero
+      case Some(s) => java.lang.Long.valueOf(s)
+    }
+
+    val result = to match {
+      case None => cassandraSession.selectAll(
+        EventDao.queryEvents,
+        persistentId,
+        jZero,
+        sequence
+      )
+      case Some(s) => cassandraSession.selectAll(
+        EventDao.queryEventsUpperBound,
+        persistentId,
+        jZero,
+        sequence,
+        java.lang.Long.valueOf(s)
+      )
+    }
+
+    result.map(rows => rows.map(toEventDto))
+  }
+
+
+  def toEventDto(row: Row) = {
+
+    val unixTimeStamp = row.getTime(EventDao.convertedUnixTimestampFieldName)
+
+    val serializationManifest = row.getString(EventDao.serializationManifestFieldName)
+
+    PersistentEventDto(
+      row.getString(EventDao.serializationManifestFieldName).split('.').last,
+      row.getString(EventDao.persistenceIdFieldName),
+      row.getLong(EventDao.partitionNumberFieldName),
+      row.getLong(EventDao.sequenceNumberFieldName),
+      Instant.ofEpochMilli(unixTimeStamp),
+      row.getUUID(EventDao.timestampUuidFieldName),
+      Json.parse(row.getBytes(EventDao.eventFieldName).array()),
+      serializationManifest
+    )
+  }
+
+  private def makePersistentId(entityTypeName: String, entityId: String) = s"$entityTypeName|$entityId"
+
+}
+
+object EventDao {
+
+  val persistenceIdFieldName = "persistence_id"
+  val partitionNumberFieldName = "partition_nr"
+  val sequenceNumberFieldName = "sequence_nr"
+  val timestampUuidFieldName = "timestamp"
+  val convertedUnixTimestampFieldName = s"system.toUnixTimestamp($timestampUuidFieldName)"
+  val eventFieldName = "event"
+  val serializationManifestFieldName = "ser_manifest"
+
+  val fieldNames =
+    s"""
+       |$persistenceIdFieldName,
+       |$partitionNumberFieldName,
+       |$sequenceNumberFieldName,
+       |$timestampUuidFieldName,
+       |$eventFieldName,
+       |$serializationManifestFieldName
+    """.stripMargin
+
+  def queryEvents =
+    s"""
+        SELECT $fieldNames, toUnixTimestamp($timestampUuidFieldName)
+        FROM "messages"
+        WHERE $persistenceIdFieldName = ?
+        AND $partitionNumberFieldName = ?
+        AND $sequenceNumberFieldName >= ?
+      """.stripMargin
+
+  def queryEventsUpperBound =
+    s"""
+       $queryEvents
+       AND $sequenceNumberFieldName <= ?
+      """.stripMargin
+
+}


### PR DESCRIPTION
This PR is to get feedback on feature to inspect persistent entities. The inspection result includes a) current state of the entity, and b) the entity events of specified sequence number. 

**Use case** 
The caller first requests for the *entity type name* of all persistent entities in the service, and then the caller can ask to inspect the entity with the entity type with known entity.

**Implementation**
 Combination of asking the persistent entity for current state, and to retrieve events from the read-side.
The works are separated into
- `5867101`: The "kit" where I intend to be a common lib that more services can use.
- the rest of commits detailing 3 steps for a new service to implement inspection feature.

**Requested feedback**
I would appreciate any feedback, and also on the following;
1. If there are less intrusive ways to get the current state of the entity. Currently, for new entity, it must implement a new command, and insert the behavior in the entity class. 
2. If there are ways to retrieve all entity names in the service without explicit registering.
3. Any syntactic improvement particularly at how i register this inspection
`https://github.com/lagom/online-auction-scala/compare/master...MickJermsurawong:feature/inspection?expand=1#diff-36c2466a76d3a96a78b9a564d26df23cR35`

**My next blocker**
I also want to also get the state of entity at a particular sequence number, and with inspiration from James work here https://github.com/jroper/lagom/commit/edfacf84543311cab9908f0dd4b42748d996d19f

What I have now from read side is json string of events, with serialization manifest, and factory of the entity.

I was hoping to use `PlayJsonSerializer#fromBinary(bytes: Array[Byte], manifest: String)` that can deserialize to the entity event, and then apply them to the initiated entity. `entity.behavior(state).eventHandler.applyOrElse(...)`  to get the state snapshot. I suspect I can try to explore how lagom replays the events internally, but I have yet to found the exact place. Nevertheless, it seems to be internal package, where I probably would not be able to work on it.

**Current problems**
The read-side of events, i'm hardcoding partition number to zero; sequence number will exceed 50,00 before the incremented partition (cassandra-persistence config). I can work on adjusting the partition later.

**Api sample**

The two endpoints for Item service in online-auction

- Get existing names of PE in the service, 
`http://localhost:53203/api/internal/item/inspect/entityNames` would get
```
[
"ItemEntity"
]
```
- Query current state and list of all the events
`http://localhost:53203/api/internal/item/inspect/entities/ItemEntity/<enitityId>` would get
```
{  
   "currentState":{  
      "id":"8021f570-1c75-11e7-b745-03b4f0c0feb3",
      "creator":"e621cabf-b8db-470d-acae-33695fdfac7c",
      "title":"Painting",
      "description":"Beautiful landscape",
      "currencyId":"USD",
      "increment":50,
      "reservePrice":0,
      "status":"Completed",
      "auctionDuration":"PT10S",
      "auctionStart":"2017-04-08T16:08:40.935Z",
      "auctionEnd":"2017-04-08T16:08:50.935Z"
   },
   "events":[  
      {  
         "eventName":"ItemCreated",
         "persistentId":"ItemEntity|8021f570-1c75-11e7-b745-03b4f0c0feb3",
         "partitionNumber":0,
         "sequenceNumber":1,
         "timeStamp":"2017-04-08T16:07:44.470Z",
         "offSet":"80243f60-1c75-11e7-b745-03b4f0c0feb3",
         "event":{  
            "item":{  
               "id":"8021f570-1c75-11e7-b745-03b4f0c0feb3",
               "creator":"e621cabf-b8db-470d-acae-33695fdfac7c",
               "title":"Painting",
               "description":"Beautiful landscape",
               "currencyId":"USD",
               "increment":50,
               "reservePrice":0,
               "status":"Created",
               "auctionDuration":"PT10S"
            }
         },
         "serializationManifest":"com.example.auction.item.impl.ItemCreated"
      },
      {  
         "eventName":"AuctionStarted",
         "persistentId":"ItemEntity|8021f570-1c75-11e7-b745-03b4f0c0feb3",
         "partitionNumber":0,
         "sequenceNumber":2,
         "timeStamp":"2017-04-08T16:08:40.936Z",
         "offSet":"a1cc4680-1c75-11e7-b745-03b4f0c0feb3",
         "event":{  
            "startTime":"2017-04-08T16:08:40.935Z"
         },
         "serializationManifest":"com.example.auction.item.impl.AuctionStarted"
      }
   ]
}
```

