### PR TITLE
Allow webgateway to start if user service is down

### DIFF
--- a/web-gateway/app/controllers/AbstractController.scala
+++ b/web-gateway/app/controllers/AbstractController.scala
@@ -29,7 +29,12 @@ abstract class AbstractController(messagesApi: MessagesApi, userService: UserSer
   }
 
   protected def loadNav(userId: Option[UUID])(implicit rh: RequestHeader): Future[Nav] = {
-    userService.getUsers.invoke().map { users =>
+    userService.getUsers.invoke()
+      //If the user service is unavailable for any reason, return an empty list of users
+      .recover {
+        case e => Seq.empty[User]
+      }
+      .map { users =>
       val user = userId.flatMap(uid => users.find(_.id == uid))
       Nav(messagesApi.preferred(rh), users, user)
     }


### PR DESCRIPTION
These changes allow the webgateway web application to be rendered even if the other services are unavailable. A service locator is still required (only active during runAll in dev mode).