### PR TITLE
Bump sbt-reactive-app plugin to 1.4.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,4 +7,4 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.8")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 // Platform Tooling plugin
-addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.1.0")
+addSbtPlugin("com.lightbend.rp" % "sbt-reactive-app" % "1.4.0")


### PR DESCRIPTION
Should fix https://github.com/lagom/online-auction-scala/issues/83.

1.1.0 is an old version and doesn't work for me out of the box. 1.4.0 works for me.